### PR TITLE
update sanitize_fields() - exclude quoted table names from sanitizing

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -200,12 +200,19 @@ class DatabaseQuery(object):
 
 		for field in self.fields:
 			if regex.match(field):
-				if any(keyword in field.lower() for keyword in blacklisted_keywords):
+				field_lower = field.lower()
+				tab_name = re.search(r'`.*?`', field_lower)
+				if tab_name:
+					#remove table name from comparison, quoted name only with ``
+					#example: table (project update in erpnext) contains the update blacklist! 
+					field_lower = field_lower.replace(tab_name.group(0),"")
+				if any(keyword in field_lower for keyword in blacklisted_keywords):
 					_raise_exception()
 
-				if any("{0}(".format(keyword) in field.lower() \
+				if any("{0}(".format(keyword) in field_lower \
 					for keyword in blacklisted_functions):
 					_raise_exception()
+
 
 	def extract_tables(self):
 		"""extract tables from fields"""


### PR DESCRIPTION
sanitize_fields does not exclude table quoted table name like `tabProject Update` which exists in ERPNext,
thus I updated the code to do that so an exception does not occur when you open Project Update Doctype.

Before Edit: 
![before](https://user-images.githubusercontent.com/9443874/37893948-cf15a8ee-30dc-11e8-8f62-95f7d9d5aceb.png)

After Edit: 
![after](https://user-images.githubusercontent.com/9443874/37893947-cef4606c-30dc-11e8-8f63-0748c686a743.png)

