### PR TITLE
Update awesome_bar.js

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -54,7 +54,7 @@ frappe.search.AwesomeBar = Class.extend({
 			// if(txt && txt.length > 1) {
 			// 	me.global.get_awesome_bar_options(txt.toLowerCase(), me);
 			// }
-
+			txt = __(txt);
 			var $this = $(this);
 			clearTimeout($this.data('timeout'));
 


### PR DESCRIPTION
I Added a line that makes it possible to search using default langauge or english
Since it used to only search using the default langauge only

before edit:
![before_code](https://user-images.githubusercontent.com/9443874/37907106-7208eed6-3104-11e8-93db-3cba3c20b26f.png)

After edit:
![after_code](https://user-images.githubusercontent.com/9443874/37907120-797b9b8c-3104-11e8-8593-c0d0e37c00bd.png)

As you see, you can search in english even though it is not the default
Note 1: You have to type a whole word like (Employee), Emp won't work.
Note 2: if you wrote a word like (Salary) and had no results, this is because the word Salary isn't translated in you language, maybe (Salary Structure) as whole is translated but this doesn't help
you need the word alone to have a translation
Note 3: This is only a fast workaround to the problem, but the actual solution would take time which I'm planning in doing.
